### PR TITLE
change authorization header to mock a logged in user

### DIFF
--- a/app/Home.js
+++ b/app/Home.js
@@ -171,7 +171,15 @@ export default class HomeScreen extends Component {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${this.state.user.idToken}`
+        'Authorization': JSON.stringify({
+          id: this.state.user.id,
+          name: this.state.user.name,
+          email: this.state.user.email,
+          photo: this.state.user.photo,
+          idToken: this.state.user.idToken,
+          accessToken: this.state.user.accessToken,
+          phoneNumber: this.state.phoneNumber
+        })
       },
       body: JSON.stringify({phoneNumber: this.state.phoneNumber})
       })


### PR DESCRIPTION
This will set up mocking authentication until oAuth is properly set up. We'll
send all of the users information along in the authorization header for
now so we can identify the user.